### PR TITLE
Enable vsc debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ hemtt
 *.bat
 *.dll
 .hemttout/*
-.vscode

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -29,6 +29,9 @@ git_hash = 0 # Disabled
 author = "Crowdedlight"
 url = "https://github.com/Crowdedlight/Crows-Electronic-Warfare"
 
+[asc]
+enabled = false   # need to deactivate this for the time being because of a bug with prefix paths; further details at:
+                  # https://discord.com/channels/976165959041679380/1039189045655392389/1201275092928299189 (ACE Discord)
 
 # Launched with `hemtt launch`
 [hemtt.launch.default]
@@ -39,6 +42,8 @@ workshop = [
     "2369477168", # Advanced Developer Tools
     "2018593688", # Zeus Enhanced ACE Compat
     "463939057",  # ACE
+    "1645973522", # Intercept Minimal Dev
+    "1585582292", # Arma Debug Engine
 ]
 parameters = [
     "C:\\Users\\crow\\Documents\\Arma 3 - Other Profiles\\Crowdedlight\\missions\\dev_mini.Enoch\\mission.sqm", # Launch into existing Editor Mission

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "connect",
+            "type": "sqf",
+            "request": "launch",
+            "missionRoot": "${workspaceFolder}",
+            "scriptPrefix": "z\\crowsEW"
+        }
+    ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-#### © 2021 Crowdedlight
+#### © 2021-2013 Crowdedlight
 <a rel="license" href="https://www.bistudio.com/community/licenses/arma-public-license-share-alike" target="_blank" >
    <img src="https://www.bistudio.com/assets/img/licenses/APL-SA.png" >
    <br>


### PR DESCRIPTION
When merged Visual Studio Code and `hemtt launch` will be prepared to enable debugging (see screenshot below).
![image](https://github.com/Crowdedlight/Crows-Electronic-Warfare/assets/76476468/2def4859-0b64-4b5d-b03a-487b3bd8c3d9)

Requires these 2x mods:
- [Arma Debug Engine](https://steamcommunity.com/sharedfiles/filedetails/?id=1585582292)
- [Intercept Minimal Dev](https://steamcommunity.com/sharedfiles/filedetails/?id=1645973522)


For further information:
- watch [Dedmens explanation video on YouTube](https://www.youtube.com/watch?v=Y70b3uQvRoQ)
- visit [Dedmens Discord](https://discord.com/channels/451451698947424266/681540975474376756)
