### PR TITLE
hidden c-motion that by acceident was made public before PR merge

### DIFF
--- a/addons/spectrum/CfgWeapons.hpp
+++ b/addons/spectrum/CfgWeapons.hpp
@@ -95,8 +95,8 @@
 		author = "Crowdedlight";
 		displayName = "C-MOTION";
 		descriptionShort = "Tracking device that gets triggered by motion and sends signals that can be seen with the spectrum device";
-		scope = PUBLIC;
-		scopeCurator = PUBLIC;
+		scope = HIDDEN;
+		scopeCurator = HIDDEN;
 		model = QPATHTOF(data\c_motion\c_motion.p3d);
 		picture = QPATHTOF(data\c_motion\cmotion_picture_ca.paa);
 		icon = QPATHTOF(data\c_motion\cmotion_icon_ca.paa);


### PR DESCRIPTION
Hides C-motion model from ingame. As it is currently not implemented but just added the model for #54 

Should be changed to "PUBLIC" in #54 