### PR TITLE
add context action for zeus to toggle jammers on/off

### DIFF
--- a/addons/main/functions/fnc_addJammerServer.sqf
+++ b/addons/main/functions/fnc_addJammerServer.sqf
@@ -68,6 +68,8 @@ if (_enabled) then {
 	// };
 };
 
+// set variable on unit that its a jammer. Helps checking if zeus should get right-click context option, compared to checking if exists going through all jammers etc. 
+_unit setVariable[QGVAR(isJammer), true, true];
 
 // Experiment information from logging data hits
 // Results: that explosive damage should be > 0.5, and hit value > 100

--- a/addons/main/functions/fnc_removeJammerServer.sqf
+++ b/addons/main/functions/fnc_removeJammerServer.sqf
@@ -49,3 +49,6 @@ if (_broadcast) then {
 if (isServer && hasInterface) then {
 	[[_netid]] call FUNC(removeJamMarkers); 
 };
+
+// remove jammer variable from object. For zeus context action
+_jammerObj setVariable[QGVAR(isJammer), false, true];

--- a/addons/main/functions/fnc_toggleJammerServer.sqf
+++ b/addons/main/functions/fnc_toggleJammerServer.sqf
@@ -27,7 +27,9 @@ GVAR(jamMap) set [_netId, _jammer];
 
 // show jammers in the spectrum
 if (_enabled) then {
-	[_jammer#0, 433, 300, "sweep"] call EFUNC(spectrum,addBeaconServer);
+	// _radFalloff + _radEffective;
+	private _range = _jammer#1 + _jammer#2;
+	[_jammer#0, 433, _range, "sweep"] call EFUNC(spectrum,addBeaconServer);
 } else {
 	[_jammer#0] call EFUNC(spectrum,removeBeaconServer);
 };

--- a/addons/main/functions/fnc_updateJamMarker.sqf
+++ b/addons/main/functions/fnc_updateJamMarker.sqf
@@ -9,7 +9,7 @@ Return: none
 updates local marker for the jammer to show on map. Only called for zeus, so only zeus can see the jammer radius
 
 *///////////////////////////////////////////////
-params ["_jammer", "_netId", "_radFalloff", "_radEffective", "_updating", "_enabled"];
+params ["_jammer", "_netID", "_radFalloff", "_radEffective", "_updating", "_enabled"];
 
 // delete existing marker, unless we are creating them first time
 if (_updating) then {
@@ -18,20 +18,20 @@ if (_updating) then {
 };
 
 // falloff + effective marker, shows the entire marker
-private _netID = createMarkerLocal [_netID, position _jammer];
-_netID setMarkerShapeLocal "ELLIPSE";
-_netID setMarkerSizeLocal [_radFalloff + _radEffective, _radFalloff + _radEffective];
-_netID setMarkerAlphaLocal 0.5;
+private _falloff = createMarkerLocal [_netID, position _jammer];
+_falloff setMarkerShapeLocal "ELLIPSE";
+_falloff setMarkerSizeLocal [_radFalloff + _radEffective, _radFalloff + _radEffective];
+_falloff setMarkerAlphaLocal 0.5;
 
 // effective marker, shows where jamming will be 100%
-private _netID_effective = createMarkerLocal [_netID + "_effective", position _jammer];
-_netID_effective setMarkerShapeLocal "ELLIPSE";
-_netID_effective setMarkerSizeLocal [_radEffective, _radEffective];
-_netID_effective setMarkerAlphaLocal 0.3;
-_netID_effective setMarkerColorLocal "ColorBlack";
+private _effective = createMarkerLocal [_netID + "_effective", position _jammer];
+_effective setMarkerShapeLocal "ELLIPSE";
+_effective setMarkerSizeLocal [_radEffective, _radEffective];
+_effective setMarkerAlphaLocal 0.3;
+_effective setMarkerColorLocal "ColorBlack";
 
 // handle difference between active and inactive jammers
 if (_enabled) then {
-	_netID setMarkerColorLocal "ColorYellow";	// allow Zeus to distinguish which jammer is turned on or off
-	_netID_effective setMarkerColorLocal "ColorRed";
+	_falloff setMarkerColorLocal "ColorYellow";	// allow Zeus to distinguish which jammer is turned on or off
+	_effective setMarkerColorLocal "ColorRed";
 };

--- a/addons/zeus/functions/fnc_zeusRegister.sqf
+++ b/addons/zeus/functions/fnc_zeusRegister.sqf
@@ -65,4 +65,20 @@ private _moduleList = [GVAR(hasTFAR), GVAR(hasACRE)] call {
 	] call zen_custom_modules_fnc_register;
 } forEach _moduleList;
 
+// context actions
+private _contextActionList = [
+    // Action name, Display name, Icon and Icon colour, code, Condition to show, arguments, dynamic children, modifier functions
+    [
+        [QGVAR(toggle_jammer_on_off),"Toggle On/off","\a3\Ui_F_Curator\Data\RscCommon\RscAttributeInventory\filter_0_ca.paa", {_hoveredEntity getVariable[QEGVAR(main,isJammer), false]}, {[netId _hoveredEntity] call EFUNC(main,actionJamToggle)}] call zen_context_menu_fnc_createAction,
+        ["Jammer"],
+        0
+    ]
+];
+{
+    [
+        // action, parent path, priority
+        (_x select 0), (_x select 1), (_x select 2)
+    ] call zen_context_menu_fnc_addAction;
+} forEach _contextActionList;
+
 diag_log format ["CrowsEW:fnc_zeusRegister: Zeus initialization complete. Zeus Enhanced Detected: %2",_hasZen];

--- a/addons/zeus/functions/fnc_zeusRegister.sqf
+++ b/addons/zeus/functions/fnc_zeusRegister.sqf
@@ -69,8 +69,10 @@ private _moduleList = [GVAR(hasTFAR), GVAR(hasACRE)] call {
 private _contextActionList = [
     // Action name, Display name, Icon and Icon colour, code, Condition to show, arguments, dynamic children, modifier functions
     [
-        [QGVAR(toggle_jammer_on_off),"Toggle On/off","\a3\Ui_F_Curator\Data\RscCommon\RscAttributeInventory\filter_0_ca.paa", {_hoveredEntity getVariable[QEGVAR(main,isJammer), false]}, {[netId _hoveredEntity] call EFUNC(main,actionJamToggle)}] call zen_context_menu_fnc_createAction,
-        ["Jammer"],
+        [QGVAR(context_menu_jammer),"Jammer","\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\call_ca.paa", {}, {!isNull _hoveredEntity && {_hoveredEntity getVariable[QEGVAR(main,isJammer), false]}}, [], {[
+			[[QGVAR(context_menu_toggle_jammer_on_off),"Toggle On/off","\a3\modules_f\data\portraitmodule_ca.paa", {[null, null, null, [netId _hoveredEntity]] call EFUNC(main,actionJamToggle)}] call zen_context_menu_fnc_createAction, [], 0]
+		]}] call zen_context_menu_fnc_createAction,
+        [],
         0
     ]
 ];

--- a/wiki/jamming/general.md
+++ b/wiki/jamming/general.md
@@ -19,7 +19,7 @@ This should make it more clear and easier to apply for mission makers to get the
 
 ## Zeus Immunity and Map Markers
 Zeus will not be radio jammed, but might not be able to hear TFAR players transmitting inside jamming area, if that player is totally jammed. 
-Zeus has a mapmarker that shows the position of all jammers and will update with jammer movements. If the jammer is active the marker will be yellow. Each jammer has two markers, the inner `effective` radius in red, and the outer `falloff` radius in yellow. 
+Zeus has two mapmarkers for each jammer. Outer one shows the `falloff` radius, and the inner one shows the `effective` radius. Thus zeus can see the position of all jammers and their area of effect. The markers will update if jammer is moved. If the jammer is active the `falloff`marker will be yellow and the `effective` radius will be red. 
 
 ## How to place such a jammer
 
@@ -53,3 +53,8 @@ A lot of antenna objects are not destructable and as such you cannot blow them u
 
 ![image](https://github.com/Crowdedlight/Crows-Electronic-Warfare/assets/76476468/7b01696a-9269-434f-8577-d989005d4a0b)
 
+
+## Zeus Context Actions - Toggle Jammer on/off
+
+Zeus can toggle the jammer on and off with the ZEN right-click menu. If done on a jammer you will se a `jammer` option and in that a `Toggle On/Off` option. This makes it easy and quick for zeus to enable or disable jammers. 
+![image](https://github.com/Crowdedlight/Crows-Electronic-Warfare/assets/7889925/1c0e9939-c7d5-45d0-b02f-c8c018ab6794)


### PR DESCRIPTION
Fixes #82 

**todo**

- [x] Test it works
- [x] Test you can't call it on non-jammers, or objects that have been jammers, but no longer are
- [x] Test it can't be set on destroyed jammers
- [x] Update wiki with feature
- [x] Change icon to something that makes sense of toggle on/off. Basegame zeus likely have an icon that would work! 