### PR TITLE
not applying jamming effect if current effect of radio is boosted, to…

### DIFF
--- a/.hemtt/missions/dev_mini.Enoch/mission.sqm
+++ b/.hemtt/missions/dev_mini.Enoch/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"ace_ballistics",
 	"A3_Weapons_F_Enoch_Pistols_ESD",
 	"crowsEW_spectrum",
+	"acre_main",
 	"ace_goggles",
 	"ace_nightvision",
 	"ace_hearing",
@@ -64,7 +65,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=27;
+		items=28;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -122,130 +123,137 @@ class AddonsMetaData
 		};
 		class Item8
 		{
+			className="acre_main";
+			name="ACRE2 - Main";
+			author="ACRE2Team";
+			url="https://github.com/IDI-Systems/acre2";
+		};
+		class Item9
+		{
 			className="ace_goggles";
 			name="ACE3 - Goggles";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item9
+		class Item10
 		{
 			className="ace_nightvision";
 			name="ACE3 - Night Vision";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item10
+		class Item11
 		{
 			className="ace_hearing";
 			name="ACE3 - Hearing";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item11
+		class Item12
 		{
 			className="ace_medical_engine";
 			name="ACE3 - Medical Engine";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item12
+		class Item13
 		{
 			className="ace_medical_treatment";
 			name="ACE3 - Medical Treatment";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item13
+		class Item14
 		{
 			className="ace_attach";
 			name="ACE3 - Attach";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item14
+		class Item15
 		{
 			className="ace_chemlights";
 			name="ace_chemlights";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item15
+		class Item16
 		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item16
+		class Item17
 		{
 			className="A3_Structures_F";
 			name="Arma 3 - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item17
+		class Item18
 		{
 			className="A3_Props_F_Enoch";
 			name="Arma 3 Contact Platform - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item18
+		class Item19
 		{
 			className="A3_Structures_F_Heli";
 			name="Arma 3 Helicopters - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item19
+		class Item20
 		{
 			className="A3_Props_F_Exp";
 			name="Arma 3 Apex - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item20
+		class Item21
 		{
 			className="crowsEW_editormodules";
 			name="editormodules";
 			author="Crowdedlight";
 		};
-		class Item21
+		class Item22
 		{
 			className="A3_Soft_F_Gamma";
 			name="Arma 3 - Unarmored Land Vehicles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item22
+		class Item23
 		{
 			className="A3_Soft_F_Exp";
 			name="Arma 3 Apex - Unarmored Land Vehicles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item23
+		class Item24
 		{
 			className="ace_cargo";
 			name="ACE3 - Cargo";
 			author="ACE-Team";
 			url="https://ace3.acemod.org/";
 		};
-		class Item24
+		class Item25
 		{
 			className="A3_Air_F_Orange";
 			name="Arma 3 Orange - Aircraft";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item25
+		class Item26
 		{
 			className="A3_Soft_F";
 			name="Arma 3 Alpha - Unarmored Land Vehicles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item26
+		class Item27
 		{
 			className="A3_Drones_F";
 			name="Arma 3 Beta - Drones";

--- a/.hemtt/missions/dev_mini.Enoch/mission.sqm
+++ b/.hemtt/missions/dev_mini.Enoch/mission.sqm
@@ -37,7 +37,6 @@ addons[]=
 	"ace_ballistics",
 	"A3_Weapons_F_Enoch_Pistols_ESD",
 	"crowsEW_spectrum",
-	"acre_main",
 	"ace_goggles",
 	"ace_nightvision",
 	"ace_hearing",
@@ -120,13 +119,6 @@ class AddonsMetaData
 			className="crowsEW_spectrum";
 			name="spectrum";
 			author="Crowdedlight";
-		};
-		class Item8
-		{
-			className="acre_main";
-			name="ACRE2 - Main";
-			author="ACRE2Team";
-			url="https://github.com/IDI-Systems/acre2";
 		};
 		class Item9
 		{

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -72,8 +72,8 @@ workshop = [
     "2369477168", # Advanced Developer Tools
     "2018593688", # Zeus Enhanced ACE Compat
     "463939057",  # ACE
-    "1645973522", # Intercept Minimal Dev
-    "1585582292", # Arma Debug Engine
+    #"1645973522", # Intercept Minimal Dev
+    #"1585582292", # Arma Debug Engine
 ]
 mission = "dev_mini.Enoch" # Launch into existing Editor Mission
 parameters = [

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -14,7 +14,7 @@ PREP(removeJammerArrayServer);
 PREP(satcomServerLoop);
 PREP(addSatcom);
 PREP(removeSatcom);
-PREP(satcomServerMapDisplay);
+PREP(satcomZeusMapDisplay);
 PREP(updateSatcomMarker);
 PREP(removeSatcomMarker);
 PREP(applyInterferenceTFAR);

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -68,7 +68,7 @@ private _waitZeus = [player] spawn
 	// call function to set eventHandler - Zeus should be initialized by now, so we can check if zeus or not
 	if (call EFUNC(zeus,isZeus)) then {
 		// handler for satcom markers
-		GVAR(PFH_satcomMarkerHandler) = [FUNC(satcomServerMapDisplay) , 0.1] call CBA_fnc_addPerFrameHandler;
+		GVAR(PFH_satcomMarkerHandler) = [FUNC(satcomZeusMapDisplay), 0.5] call CBA_fnc_addPerFrameHandler;
 		// event handler for removal of satcom markers. Required to not leave dangling map-markers
 		private _removeSatcomMarkerId = [QGVAR(removeSatcomMarker), FUNC(removeSatcomMarker)] call CBA_fnc_addEventHandler;		
 	};

--- a/addons/main/functions/fnc_addJammerServer.sqf
+++ b/addons/main/functions/fnc_addJammerServer.sqf
@@ -51,11 +51,16 @@ GVAR(jamMap) set [_netId, [_unit, _radFalloff, _radEffective, _enabled, _capabil
 [QGVAR(updateJammers), [GVAR(jamMap)]] call CBA_fnc_globalEvent;
 
 // if hosted multiplayer the jamMaps are shared between player and client for host, and thus update handler on client won't detect "new" jammers added on client side (as there is no difference between their jamMaps).
-//  So we have to add actions to jammers here
+//  So we have to add actions/markers to jammers here
 if (isServer && hasInterface) then {
 	// add actions to new jammers
 	_unit addAction ["<t color=""#FFFF00"">De-activate jammer", FUNC(actionJamToggle), [_netId], 7, true, true, "", format ["([%1] call %2)", str(_netId), FUNC(isJammerActive)], 6];
 	_unit addAction ["<t color=""#FFFF00"">Activate jammer", FUNC(actionJamToggle), [_netId], 7, true, true, "", format ["!([%1] call %2)", str(_netId), FUNC(isJammerActive)], 6];
+
+	// if zeus, add map marker for new ones
+	if (call EFUNC(zeus,isZeus)) then {
+		[_unit, _netId, _radFalloff, _radEffective, false, _enabled] call FUNC(updateJamMarker);
+	};
 };
 
 if (_enabled) then {

--- a/addons/main/functions/fnc_applyInterferenceACRE.sqf
+++ b/addons/main/functions/fnc_applyInterferenceACRE.sqf
@@ -12,6 +12,10 @@ Apply interference to ACRE radios
 
 params["_distJammer", "_radFalloff", "_radEffective"];
 
+// if their signal is boosted, we don't decrease it, as then they are under satcom boosting
+private _currentEffect = player getVariable ["acre_receive_interference", 0];
+if (_currentEffect < -1) exitWith {};
+
 // If ACRE loaded, we return calculation for signal jamming
 private _distPercent = _distJammer / _distRad;
 

--- a/addons/main/functions/fnc_applyInterferenceTFAR.sqf
+++ b/addons/main/functions/fnc_applyInterferenceTFAR.sqf
@@ -12,6 +12,10 @@ Apply interference to TFAR radios
 
 params ["_distJammer", "_radFalloff", "_radEffective"];
 
+// if their signal is boosted, we don't decrease it, as then they are under satcom boosting
+private _currentEffect = player getVariable ["tf_sendingDistanceMultiplicator", 1];
+if (_currentEffect > 1) exitWith {};
+
 private _rxInterference = 1;
 private _txInterference = 1;
 private _distPercent = 1;

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -24,7 +24,7 @@ if (call EFUNC(zeus,isZeus)) then {
 };
 
 // TFAR Jamming logic - do not run if zeus, as zeus is immune to TFAR jamming only
-// if (!(call EFUNC(zeus,isZeus))) then {
+if (!(call EFUNC(zeus,isZeus))) then {
 	// find nearest jammer within range
 	private _nearestJammer = [objNull];
 	private _distJammer = -1;
@@ -71,7 +71,7 @@ if (call EFUNC(zeus,isZeus)) then {
 			};
 		};
 	};
-// };
+};
 
 // handle drone jammers
 private _PP_film = GVAR(FilmGrain_jamEffect);

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -24,7 +24,7 @@ if (call EFUNC(zeus,isZeus)) then {
 };
 
 // TFAR Jamming logic - do not run if zeus, as zeus is immune to TFAR jamming only
-if (!(call EFUNC(zeus,isZeus))) then {
+// if (!(call EFUNC(zeus,isZeus))) then {
 	// find nearest jammer within range
 	private _nearestJammer = [objNull];
 	private _distJammer = -1;
@@ -71,7 +71,7 @@ if (!(call EFUNC(zeus,isZeus))) then {
 			};
 		};
 	};
-};
+// };
 
 // handle drone jammers
 private _PP_film = GVAR(FilmGrain_jamEffect);

--- a/addons/main/functions/fnc_satcomZeusMapDisplay.sqf
+++ b/addons/main/functions/fnc_satcomZeusMapDisplay.sqf
@@ -2,7 +2,7 @@
 /*/////////////////////////////////////////////////
 Author: Crowdedlight
 			   
-File: fnc_satcomServerMapDisplay.sqf
+File: fnc_satcomZeusMapDisplay.sqf
 Parameters: 
 Return: none
 
@@ -18,6 +18,6 @@ if (count _list == 0) exitWith {};
 // loop through all current active objects to update map-markers
 {
 	_y params["_emitter", "_radius"];
-	// jamObj, netId, radius
+	// satcom obj, netId, radius, updating
 	[_emitter, _x, _radius, true] call FUNC(updateSatcomMarker);
 } forEach _list;

--- a/addons/main/functions/fnc_toggleJammerServer.sqf
+++ b/addons/main/functions/fnc_toggleJammerServer.sqf
@@ -41,4 +41,3 @@ if (_enabled) then {
 } else {
 	[_jammer#0] call EFUNC(spectrum,removeBeaconServer);
 };
-

--- a/addons/main/functions/fnc_updateJamMarker.sqf
+++ b/addons/main/functions/fnc_updateJamMarker.sqf
@@ -11,27 +11,35 @@ updates local marker for the jammer to show on map. Only called for zeus, so onl
 *///////////////////////////////////////////////
 params ["_jammer", "_netID", "_radFalloff", "_radEffective", "_updating", "_enabled"];
 
-// delete existing marker, unless we are creating them first time
-if (_updating) then {
-	deletemarkerLocal _netID;
-	deletemarkerLocal (_netID + "_effective");
-};
-
-// falloff + effective marker, shows the entire marker
-private _falloff = createMarkerLocal [_netID, position _jammer];
-_falloff setMarkerShapeLocal "ELLIPSE";
-_falloff setMarkerSizeLocal [_radFalloff + _radEffective, _radFalloff + _radEffective];
-_falloff setMarkerAlphaLocal 0.5;
-
-// effective marker, shows where jamming will be 100%
-private _effective = createMarkerLocal [_netID + "_effective", position _jammer];
-_effective setMarkerShapeLocal "ELLIPSE";
-_effective setMarkerSizeLocal [_radEffective, _radEffective];
-_effective setMarkerAlphaLocal 0.3;
-_effective setMarkerColorLocal "ColorBlack";
+private _marker_falloff = _netID;
+private _marker_effective = _netID + "_effective";
 
 // handle difference between active and inactive jammers
 if (_enabled) then {
-	_falloff setMarkerColorLocal "ColorYellow";	// allow Zeus to distinguish which jammer is turned on or off
-	_effective setMarkerColorLocal "ColorRed";
+	_marker_falloff setMarkerColorLocal "ColorYellow";	// allow Zeus to distinguish which jammer is turned on or off
+	_marker_effective setMarkerColorLocal "ColorRed";
+};
+
+// if updating then we just move the position
+if (_updating) then {
+	_marker_falloff setMarkerPosLocal _jammer;
+	_marker_effective setMarkerPosLocal _jammer;
+} else {
+
+	// falloff + effective marker, shows the entire marker
+	_marker_falloff = createMarkerLocal [_marker_falloff, position _jammer];
+	_marker_falloff setMarkerDrawPriority -1;
+	_marker_falloff setMarkerTypeLocal "";
+	_marker_falloff setMarkerShapeLocal "ELLIPSE";
+	_marker_falloff setMarkerSizeLocal [_radFalloff + _radEffective, _radFalloff + _radEffective];
+	_marker_falloff setMarkerAlphaLocal 0.5;
+	
+	// effective marker, shows where jamming will be 100%
+	_marker_effective = createMarkerLocal [_marker_effective, position _jammer];
+	_marker_effective setMarkerDrawPriority -1;
+	_marker_effective setMarkerTypeLocal "";
+	_marker_effective setMarkerShapeLocal "ELLIPSE";
+	_marker_effective setMarkerSizeLocal [_radEffective, _radEffective];
+	_marker_effective setMarkerAlphaLocal 0.3;
+	_marker_effective setMarkerColorLocal "ColorBlack";
 };

--- a/addons/main/functions/fnc_updateJammers.sqf
+++ b/addons/main/functions/fnc_updateJammers.sqf
@@ -23,11 +23,16 @@ private _newJammers = (keys _jamMap) - (keys GVAR(jamMap));
 {
 	private _netId = _x;
 	// get object from hashmap
-	(_jamMap get _x) params ["_unit"];
+	(_jamMap get _x) params ["_unit", "_radFalloff", "_radEffective", "_enabled"];
 	
 	// add actions to new jammers
 	_unit addAction ["<t color=""#FFFF00"">De-activate jammer", FUNC(actionJamToggle), [_netId], 7, true, true, "", format ["([%1] call %2)", str(_netId), FUNC(isJammerActive)], 6];
 	_unit addAction ["<t color=""#FFFF00"">Activate jammer", FUNC(actionJamToggle), [_netId], 7, true, true, "", format ["!([%1] call %2)", str(_netId), FUNC(isJammerActive)], 6];
+
+	// if zeus, add map marker for new ones
+	if (call EFUNC(zeus,isZeus)) then {
+		[_unit, _netId, _radFalloff, _radEffective, false, _enabled] call FUNC(updateJamMarker);
+	};
 } forEach _newJammers;
 
 // reset effects if 0, as 0 == no logic being run in local PFH

--- a/addons/main/functions/fnc_updateSatcomMarker.sqf
+++ b/addons/main/functions/fnc_updateSatcomMarker.sqf
@@ -11,13 +11,17 @@ updates local markers
 *///////////////////////////////////////////////
 params ["_obj", "_netId", "_radius", "_updating"];
 
+private _marker = _netId;
+
 // delete existing marker, unless we are creating them first time
 if (_updating) then {
-	deletemarkerLocal _netID;
+	_marker setMarkerPosLocal _obj;
+} else {
+	_marker = createMarkerLocal [_marker, position _obj];
+	_marker setMarkerDrawPriority 2; // Setting as higher priority to be drawn on top of my other jammer markers. This help remove the "blinking" behaviour when two markers of same priority draw on top of eachother every second draw. 
+	_marker setMarkerTypeLocal "";
+	_marker setMarkerShapeLocal "ELLIPSE";
+	_marker setMarkerSizeLocal [_radius, _radius];
+	_marker setMarkerAlphaLocal 0.2;
+	_marker setMarkerColorLocal "ColorBlue";	
 };
-
-_netID = createMarkerLocal [_netID, position _obj];
-_netID setMarkerShapeLocal "ELLIPSE";
-_netID setMarkerSizeLocal [_radius, _radius];
-_netID setMarkerAlphaLocal 0.2;
-_netID setMarkerColorLocal "ColorBlue";

--- a/addons/zeus/functions/fnc_zeusRegister.sqf
+++ b/addons/zeus/functions/fnc_zeusRegister.sqf
@@ -49,7 +49,7 @@ private _moduleList = [GVAR(hasTFAR), GVAR(hasACRE)] call {
 	if (_isTFARLoaded) then {
 		_modules = _modules + _tfarModules;
 	};
-	if (_isTFARLoaded || isACRELoaded) then {
+	if (_isTFARLoaded || _isACRELoaded) then {
 		_modules = _modules + _radioModules;
 	};
 	_modules;

--- a/wiki/introduction.md
+++ b/wiki/introduction.md
@@ -4,3 +4,6 @@ This wiki contains the documentation of the features of Crows Electronic Warfare
 
 As documentation takes time to write, not everything will be documented immediately, but feel free to make pull-requests if you wish to expand or fix missing or lacking documentation!
 
+```admonish info
+For now ACRE is only supported for radio jamming and SATCOM. Radio tracking and listening to enemy radio transmissions are only available with TFAR.
+```

--- a/wiki/satcom/radio-boosting.md
+++ b/wiki/satcom/radio-boosting.md
@@ -1,2 +1,4 @@
 # SatCom
-The satcom module can be set to make an object or vehicle a TFAR booster in range. It will show a blue circle for Zeus only of the area of effect. Any units within this area will have their TFAR range boosted. It can help counteract enemy jammers, as long as you are within the area of effect. 
+The satcom module can be set to make an object or vehicle a radio booster. It will show a blue circle for Zeus indicating the area of effect. Any units within this area will have their radio range boosted. The thought behind it is that you use satellite equipment to have up to 4 times the range on your radio comms. That does mean that if you are within the SATCOM area of effect, even if you are inside a effective jammer radius, you comms will still be boosted, as the satellite equipment is not being jammed. 
+
+I know this is not really how it works irl, but for simplicity sake this is how it is implemented for now. It might change to better be influenced by jammers in the future.


### PR DESCRIPTION
Fixes #80 

This makes the radio jamming not affect units that are currently getting their radio boosted. So idea is if you are under SATCOM influence with the Satcom device from the ILBE TFAR mod, or within the influence of the radius from the satcom module. Ideal implementation would be it "fighting" back against radio jamming, but for simplicity, the initial implementation here is just that you are within range of "satellite comms" equipment and use frequencies outside the jamming range of current devices. 
So a little bit more "arcade" implementation. 

If time permits in future it could be cool to adapt it to interact more with jamming, than either or. 

**Todo:**

- [ ] Test function. Verify if the variables set on players jumps between satcom and jamming