### PR TITLE
configurable ranges for jammable drones

### DIFF
--- a/addons/spectrum/XEH_preInit.sqf
+++ b/addons/spectrum/XEH_preInit.sqf
@@ -41,7 +41,7 @@ ADDON = true;
     nil
 ] call CBA_fnc_addSetting;
 
-// Jamming Default Signals
+// Default jammable classes
 [
     QGVAR(defaultClassForJammingSignal), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "EDITBOX", // setting type
@@ -50,6 +50,18 @@ ADDON = true;
     "UGV_01_base_F,UGV_02_Base_F,UAV_01_base_F,UAV_02_base_F,UAV_03_base_F,UAV_04_base_F,UAV_05_Base_F,UAV_06_base_F", // all drones & UGV by default
     true, // is global, gotta be equal for all
 	FUNC(jammableDronesInit),
+	true // need mission restart - Required as I can't remove the existing class eventhandlers made on init
+] call CBA_fnc_addSetting;
+
+// Default signal ranges for jammable classes
+[
+    QGVAR(defaultRangesForJammingSignal), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "EDITBOX", // setting type
+    [localize "STR_CROWSEW_Spectrum_settings_default_signal_range_for_jammable_drones", localize "STR_CROWSEW_Spectrum_settings_default_signal_range_for_jammable_drones_tooltip"], 
+    ["Crows Electronic Warfare", localize "STR_CROWSEW_Spectrum_settings_jamming"],
+    "298,299,301,3002,3003,3004,3005,306", // all drones & UGV shall have a range of 3km by default
+    true, // is global, gotta be equal for all
+	nil,  // no associated script because this is only a companion parameter to defaultClassForJammingSignal which will already trigger a script
 	true // need mission restart - Required as I can't remove the existing class eventhandlers made on init
 ] call CBA_fnc_addSetting;
 

--- a/addons/spectrum/functions/fnc_initDroneSignals.sqf
+++ b/addons/spectrum/functions/fnc_initDroneSignals.sqf
@@ -29,6 +29,9 @@ private _signalRange = 300;
 private _defaultRanges = [GVAR(defaultRangesForJammingSignal), ","] call CBA_fnc_split;
 {
 	if (_unit isKindOf _x) then {
+		if (count _defaultRanges < _forEachIndex+1) then {
+				diag_log format ["CrowsEW:fnc_initDroneSignals.sqf: '%1' is %2 elements long. You tried to access index %3. Range will use fallback value.", QGVAR(defaultRangesForJammingSignal), count _defaultRanges, _forEachIndex]; 
+		};
 		_signalRange = parseNumber (_defaultRanges#_forEachIndex);
 	};
 } forEach ([GVAR(defaultClassForJammingSignal), ","] call CBA_fnc_split);

--- a/addons/spectrum/functions/fnc_initDroneSignals.sqf
+++ b/addons/spectrum/functions/fnc_initDroneSignals.sqf
@@ -24,8 +24,17 @@ if (GVAR(beacons) findIf { _x#0 == _unit } > -1) exitWith {};
 private _range = abs((GVAR(spectrumDeviceFrequencyRange)#2)#0 - (GVAR(spectrumDeviceFrequencyRange)#2)#1);
 private _freq = 433.00 + (random _range);
 
+// get signal range from CBA settings
+private _signalRange = 300;
+private _defaultRanges = [GVAR(defaultRangesForJammingSignal), ","] call CBA_fnc_split;
+{
+	if (_unit isKindOf _x) then {
+		_signalRange = parseNumber (_defaultRanges#_forEachIndex);
+	};
+} forEach ([GVAR(defaultClassForJammingSignal), ","] call CBA_fnc_split);
+
 // add beacon
-[_unit, _freq, 300, "drone"] call FUNC(addBeaconServer);
+[_unit, _freq, _signalRange, "drone"] call FUNC(addBeaconServer);
 
 // set empty array on unit var where the players currently jamming is listed 
 _unit setVariable [QGVAR(activeJammingObjects), []];

--- a/addons/spectrum/functions/fnc_initDroneSignals.sqf
+++ b/addons/spectrum/functions/fnc_initDroneSignals.sqf
@@ -26,13 +26,13 @@ private _freq = 433.00 + (random _range);
 
 // get signal range from CBA settings
 private _signalRange = 300;
-private _defaultRanges = [GVAR(defaultRangesForJammingSignal) trim [",", 0], ","] call CBA_fnc_split;
+private _defaultRanges = [GVAR(defaultRangesForJammingSignal) trim [" ,", 0], ","] call CBA_fnc_split;
 {
 	if (_unit isKindOf _x) then {
 		if (count _defaultRanges < _forEachIndex+1) then {
 				diag_log format ["CrowsEW:fnc_initDroneSignals.sqf: '%1' is %2 elements long. You tried to access index %3. Range will use fallback value.", QGVAR(defaultRangesForJammingSignal), count _defaultRanges, _forEachIndex]; 
 		};
-		_signalRange = parseNumber (_defaultRanges#_forEachIndex);
+		_signalRange = parseNumber (trim (_defaultRanges#_forEachIndex));
 	};
 } forEach ([GVAR(defaultClassForJammingSignal), ","] call CBA_fnc_split);
 

--- a/addons/spectrum/functions/fnc_initDroneSignals.sqf
+++ b/addons/spectrum/functions/fnc_initDroneSignals.sqf
@@ -26,7 +26,7 @@ private _freq = 433.00 + (random _range);
 
 // get signal range from CBA settings
 private _signalRange = 300;
-private _defaultRanges = [GVAR(defaultRangesForJammingSignal), ","] call CBA_fnc_split;
+private _defaultRanges = [GVAR(defaultRangesForJammingSignal) trim [",", 0], ","] call CBA_fnc_split;
 {
 	if (_unit isKindOf _x) then {
 		if (count _defaultRanges < _forEachIndex+1) then {

--- a/addons/spectrum/stringtable.xml
+++ b/addons/spectrum/stringtable.xml
@@ -161,6 +161,12 @@
             <English>The classnames that by default will spawn with spectrum signal and can be jammed. Change require mission restart. Comma seperated</English>
             <Chinesesimp>默认情况下将生成带有频谱信号并可被干扰的类名,更改需要重新启动任务.用逗号分隔</Chinesesimp>
         </Key>
+        <Key ID="STR_CROWSEW_Spectrum_settings_default_signal_range_for_jammable_drones">
+            <English>Default Jammable Drone Range</English>
+        </Key>
+        <Key ID="STR_CROWSEW_Spectrum_settings_default_signal_range_for_jammable_drones_tooltip">
+            <English>The default signal range that jammable drones spawn with. Change require mission restart. Comma seperated (same order as Default Jammable Drones)</English>
+        </Key>
         <Key ID="STR_CROWSEW_Spectrum_settings_enable_device_name">
             <English>Enable Spectrum Device</English>
             <Chinesesimp>启用频谱设备</Chinesesimp>


### PR DESCRIPTION
- adds a CBA setting to allow defining the default signal range that jammable drones spawn with

@Crowdedlight this refers to our [private chat in Discord](https://discord.com/channels/@me/1192255957816836148/1337173267873796194).


Tested using
```
Type: Public
Build: Stable
Version: 2.18.152405

hemtt 1.14.2
```

I set the default values to all be slightly different (to allow identifying different classes while testing). Per default they are all close to the previous default of 300m, with the exception of large and expensive drones that are expected to fly at larger distance to players.
![image](https://github.com/user-attachments/assets/1df7023e-467e-4d44-bfa6-112b03fd294d)


