### PR TITLE
UAV terminal use visible in the spectrum

### DIFF
--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -139,7 +139,11 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 	};
  } else {
+	// test for "drone" type signal
+	private _playerDroneSignals = EGVAR(spectrum,beacons) select { _x#0 == player && _x#3 == "drone" };	// keep drone signals/beacons
+	if (count _playerDroneSignals > 0) then {	
 		// remove signal source
 		[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
 		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
+	};
 };

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -117,8 +117,9 @@ _PP_film ppEffectCommit 0;	// commit what ever change has been made
 if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 	private _uav = getConnectedUAV player;
 	if (!isNull _uav) then {
-		private _uavTerminalSignalIsSet = player getVariable ["UAVTerminalSignalIsSet", false];
-		if (!_uavTerminalSignalIsSet) then {
+		private _droneThatUavTerminalSignalIsSetFor = player getVariable ["DroneThatUavTerminalSignalIsSetFor", objNull];
+		if (_uav != _droneThatUavTerminalSignalIsSetFor) then {
+			[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;	// remove signal source (if any)
 
 			// determine signal range and frequency
 			private _sigRange = 300;	// default value
@@ -133,15 +134,15 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 
 			// add signal source
 			[QEGVAR(spectrum,addBeacon), [player, _freq, _sigRange, "drone"]] call CBA_fnc_serverEvent;
-			player setVariable ["UAVTerminalSignalIsSet", true];	// remember signal state locally
+			player setVariable ["DroneThatUavTerminalSignalIsSetFor", _uav];	// remember signal state locally
 		};
 	} else {
 		// remove signal source
 		[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
-		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
+		player setVariable ["DroneThatUavTerminalSignalIsSetFor", objNull];	// remember signal state locally
 	};
  } else {
 	// remove signal source
 	[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
-	player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
+	player setVariable ["DroneThatUavTerminalSignalIsSetFor", objNull];	// remember signal state locally
 };

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -119,14 +119,16 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 	if (!isNull _uav) then {
 		private _uavTerminalSignalIsSet = player getVariable ["UAVTerminalSignalIsSet", false];
 		if (!_uavTerminalSignalIsSet) then {
-			// randomize frequency 
-			private _range = abs((EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#0 - (EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#1);
-			private _freq = 433.00 + (random _range);
 
-			// determine signal range
+			// determine signal range and frequency
 			private _sigRange = 300;	// default value
+			private _freq = 433;		// default value
 			{			
-				if (_x#0 == _uav) exitWith { _sigRange = _x#2 };	// use same signal range as the connected UAV
+				if (_x#0 == _uav) exitWith { 
+					_sigRange = _x#2;	// use same signal range as the connected UAV
+					private _droneToTerminalOffset = 2;		// duplex offest of drone and terminal signal in MHz
+					_freq = EGVAR(spectrum,spectrumDeviceFrequencyRange)#2#0 + ((_x#1 + _droneToTerminalOffset - EGVAR(spectrum,spectrumDeviceFrequencyRange)#2#0) mod EGVAR(spectrum,spectrumDeviceFrequencyRange)#2#2);
+				};
 			} forEach EGVAR(spectrum,beacons);
 
 			// add signal source

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -111,3 +111,30 @@ if (!isNull _drone) then {
 	};
 };
 _PP_film ppEffectCommit 0;	// commit what ever change has been made
+
+
+
+// make players connected to a drone via UAVterminal visible in the spectrum
+private _uav = getConnectedUAV player;
+if (!isNull _uav) then {
+	private _uavTerminalSignalIsSet = player getVariable ["UAVTerminalSignalIsSet", false];
+	if (!_uavTerminalSignalIsSet) then {
+		// randomize frequency 
+		private _range = abs((EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#0 - (EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#1);
+		private _freq = 433.00 + (random _range);
+
+		// determine signal range
+		private _sigRange = 300;	// default value
+		{			
+			if (_x#0 == _uav) exitWith { _sigRange = _x#2 };	// use same signal range as the connected UAV
+		} forEach EGVAR(spectrum,beacons);
+
+		// add signal source
+		[QEGVAR(spectrum,addBeacon), [player, _freq, _sigRange, "drone"]] call CBA_fnc_serverEvent;
+		player setVariable ["UAVTerminalSignalIsSet", true];	// remember signal state locally
+	};
+} else {
+	// remove signal source
+	[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
+	player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
+};

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -135,7 +135,7 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 		};
 	} else {
 		// remove signal source
-		[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
+		[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
 		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 	};
  } else {
@@ -143,7 +143,7 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 	private _playerDroneSignals = EGVAR(spectrum,beacons) select { _x#0 == player && _x#3 == "drone" };	// keep drone signals/beacons
 	if (count _playerDroneSignals > 0) then {	
 		// remove signal source
-		[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
+		[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
 		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 	};
 };

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -77,9 +77,8 @@ if (!(call EFUNC(zeus,isZeus)) || {(call EFUNC(zeus,isZeus)) && !GVAR(zeus_jam_i
 private _PP_film = GVAR(FilmGrain_jamEffect);
 _PP_film ppEffectEnable false; // restore players view back to normal if no other logic decides otherwise
 private _drone = getConnectedUAV player;
-if (!isNull _drone) then {
-	// sort drone jammers by distance to drone not distance to player (which only makes sense for VoiceCommJammers)
-	private _sortingCode = { _input0 distance _x#0 };	// sort by distance between drone and jammer
+if (!isNull _drone) then {	
+	private _sortingCode = { (_input0 distance _x#0) min (player distance _x#0) };	// sort drone jammers by distance to drone and player (which ever is smaller)
 	private _filterCode = { _x#3  && { JAM_CAPABILITY_DRONE in _x#4 } };	// keep jammers that are enabled and have the JAM_CAPABILITY_DRONE capability
 	private _droneJammersSorted = [ values GVAR(jamMap), [_drone], _sortingCode, "ASCEND", _filterCode] call BIS_fnc_sortBy; 
 	
@@ -87,12 +86,12 @@ if (!isNull _drone) then {
 	
 	private _nearestDroneJammer = _droneJammersSorted#0;
 	_nearestDroneJammer params ["_jamObj", "_radFalloff", "_radEffective", "_enabled", "_capabilities"];
-	private _distDroneToJammer = _drone distance _jamObj;
+	private _distDroneOrPlayerToJammer = (_drone distance _jamObj) min (player distance _jamObj);
 
 	// to keep consistency, if we are outside effective + falloff range of jammer, then we don't get any interference
-	if (_distDroneToJammer > (_radEffective + _radFalloff)) exitWith {};
+	if (_distDroneOrPlayerToJammer > (_radEffective + _radFalloff)) exitWith {};
 	
-	if (_distDroneToJammer < _radEffective) then {
+	if (_distDroneOrPlayerToJammer < _radEffective) then {
 		// hardest actions to take when being inside the jammer area
 		player connectTerminalToUAV objNull; // disconnect player from drone
 		hint parseText localize "STR_CROWSEW_Main_jammer_drone_jammed";	// notify player why this happened
@@ -101,7 +100,7 @@ if (!isNull _drone) then {
 		// less intense actions when drone is only approaching the jammer area (gives pilot time to react to the presence of the jammer)
 		if (isRemoteControlling player && (isNull curatorCamera)) then {	// if player uses UAV camera currently (and did not step into Zeus mode)
 			// calculate video image distortion
-			private _distDrone2killRadius = abs(_distDroneToJammer - _radEffective);
+			private _distDrone2killRadius = abs(_distDroneOrPlayerToJammer - _radEffective);
 			private _sharpness = [0, 4, _distDrone2killRadius/_radFalloff] call BIS_fnc_lerp;
 			// systemChat format ["ratio %1, _sharpness %2", _distDrone2killRadius/_radFalloff, _sharpness];
 			
@@ -115,26 +114,32 @@ _PP_film ppEffectCommit 0;	// commit what ever change has been made
 
 
 // make players connected to a drone via UAVterminal visible in the spectrum
-private _uav = getConnectedUAV player;
-if (!isNull _uav) then {
-	private _uavTerminalSignalIsSet = player getVariable ["UAVTerminalSignalIsSet", false];
-	if (!_uavTerminalSignalIsSet) then {
-		// randomize frequency 
-		private _range = abs((EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#0 - (EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#1);
-		private _freq = 433.00 + (random _range);
+if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
+	private _uav = getConnectedUAV player;
+	if (!isNull _uav) then {
+		private _uavTerminalSignalIsSet = player getVariable ["UAVTerminalSignalIsSet", false];
+		if (!_uavTerminalSignalIsSet) then {
+			// randomize frequency 
+			private _range = abs((EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#0 - (EGVAR(spectrum,spectrumDeviceFrequencyRange)#2)#1);
+			private _freq = 433.00 + (random _range);
 
-		// determine signal range
-		private _sigRange = 300;	// default value
-		{			
-			if (_x#0 == _uav) exitWith { _sigRange = _x#2 };	// use same signal range as the connected UAV
-		} forEach EGVAR(spectrum,beacons);
+			// determine signal range
+			private _sigRange = 300;	// default value
+			{			
+				if (_x#0 == _uav) exitWith { _sigRange = _x#2 };	// use same signal range as the connected UAV
+			} forEach EGVAR(spectrum,beacons);
 
-		// add signal source
-		[QEGVAR(spectrum,addBeacon), [player, _freq, _sigRange, "drone"]] call CBA_fnc_serverEvent;
-		player setVariable ["UAVTerminalSignalIsSet", true];	// remember signal state locally
+			// add signal source
+			[QEGVAR(spectrum,addBeacon), [player, _freq, _sigRange, "drone"]] call CBA_fnc_serverEvent;
+			player setVariable ["UAVTerminalSignalIsSet", true];	// remember signal state locally
+		};
+	} else {
+		// remove signal source
+		[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
+		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 	};
-} else {
-	// remove signal source
-	[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
-	player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
+ } else {
+		// remove signal source
+		[QEGVAR(spectrum,removeBeacon), [player]] call CBA_fnc_serverEvent;
+		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 };

--- a/addons/main/functions/fnc_jammerPlayerLocal.sqf
+++ b/addons/main/functions/fnc_jammerPlayerLocal.sqf
@@ -141,11 +141,7 @@ if (EGVAR(spectrum,UAVterminalUserVisibleInSpectrum)) then {
 		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 	};
  } else {
-	// test for "drone" type signal
-	private _playerDroneSignals = EGVAR(spectrum,beacons) select { _x#0 == player && _x#3 == "drone" };	// keep drone signals/beacons
-	if (count _playerDroneSignals > 0) then {	
-		// remove signal source
-		[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
-		player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
-	};
+	// remove signal source
+	[QEGVAR(spectrum,removeBeacon), [player, "drone"]] call CBA_fnc_serverEvent;
+	player setVariable ["UAVTerminalSignalIsSet", false];	// remember signal state locally
 };

--- a/addons/spectrum/XEH_preInit.sqf
+++ b/addons/spectrum/XEH_preInit.sqf
@@ -33,6 +33,15 @@ ADDON = true;
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(UAVterminalUserVisibleInSpectrum), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "CHECKBOX", // setting type
+    [localize "STR_CROWSEW_Spectrum_settings_uav_terminal_user_visible_in_spectrum", localize "STR_CROWSEW_Spectrum_settings_uav_terminal_user_visible_in_spectrum_tooltip"], 
+    "Crows Electronic Warfare",
+    false,	// bool, disabled by default to stay with current behaviour
+    nil
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(minJamSigStrength), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "SLIDER", // setting type
     [localize "STR_CROWSEW_Spectrum_settings_min_jam_strength", localize "STR_CROWSEW_Spectrum_settings_min_jam_strength_tooltip"], 

--- a/addons/spectrum/functions/fnc_drawSpectrumLine.sqf
+++ b/addons/spectrum/functions/fnc_drawSpectrumLine.sqf
@@ -25,7 +25,7 @@ _colour = GVAR(spectrumAutolineColours) # _colour;
 private _freq = ((missionNamespace getVariable ["#EM_SelMin", 141.6]) + (missionNamespace getVariable ["#EM_SelMax", 141.9]))/2;
 _freq = _freq toFixed 1;
 
-private _startPos = [[[position player, GVAR(spectrumAutolineNoise)]]] call BIS_fnc_randomPos;
+private _startPos = [[[position player, GVAR(spectrumAutolineNoise)]], []] call BIS_fnc_randomPos;
 private _endPos = _startPos getPos [GVAR(spectrumAutolineLength), getDir player];
 
 private _marker_prefix = "_USER_DEFINED"+(getPlayerUID player)+str(getPos player)+str(getDir player)+_freq;

--- a/addons/spectrum/functions/fnc_removeBeaconServer.sqf
+++ b/addons/spectrum/functions/fnc_removeBeaconServer.sqf
@@ -3,22 +3,29 @@
 Author: Crowdedlight
 			   
 File: fnc_removeBeaconServer.sqf
-Parameters: pos, _unit
+Parameters: _unit            object that has the signal, which needs removing, currently attached
+            _signalType      type of signal that shall be removed (e.g. "drone" or "sweep_radio" etc.); if this is not set, all types of signals will be removed
 Return: none
 
 remove signal source from object 
 SERVER ONLY
 
 *///////////////////////////////////////////////
-params ["_unit"];
+params ["_unit",  ["_signalType", "", ["strings_only"]]];
 
 // if object is null, exitwith. Can happen if we get event as JIP but object has been removed
 if (isNull _unit) exitWith {};
 
+// define search behaviour for deletion candidates
+private _findCode = { _x#0 == _unit };
+if (_signalType != "") then {
+	_findCode = { _x#0 == _unit && { _x#3 == _signalType } };	// look for specific signal type
+};
+
 // find object in array
 while { true } do
 {
-	private _rmIndex = GVAR(beacons) findIf { (_x select 0) == _unit};
+	private _rmIndex = GVAR(beacons) findIf _findCode;
 	GVAR(beacons) deleteAt _rmIndex;	
 
 	// breakout clause

--- a/addons/spectrum/functions/fnc_toggleJammingOnUnit.sqf
+++ b/addons/spectrum/functions/fnc_toggleJammingOnUnit.sqf
@@ -93,6 +93,9 @@ if (_enableJam) then {
 
 			// disconnect any player that might control this drone
 			private _droneUsers = (UAVControl _unit) select { !(_x isEqualType "String") };	 // leave only player objects
+			if (isPlayer _unit) then {	// players with a UAV terminal connected to a drone
+				_droneUsers pushBack _unit;
+			};
 			{
 				[QGVAR(disconnectPlayerUAV), [_x], _x] call CBA_fnc_targetEvent;
 				[QEGVAR(zeus,hintPlayer), ["STR_CROWSEW_Spectrum_hints_jammed_drone"], _x] call CBA_fnc_targetEvent; // notify player why this happened 

--- a/addons/spectrum/stringtable.xml
+++ b/addons/spectrum/stringtable.xml
@@ -199,6 +199,12 @@
             <English>Should you be able to see your own signal sources on the spectrum Device, or should they be hidden from view. If Tfar SideTrack setting is disabled, you won't see your own TFAR signal even if this setting is turned on</English>
             <Chinesesimp>您是否应该能够在频谱设备上看到自己的信号源,或者它们应该被隐藏起来.如果 Tfar SideTrack 设置被禁用,即使打开了此设置,您也看不到自己的TFAR信号.</Chinesesimp>
         </Key>
+        <Key ID="STR_CROWSEW_Spectrum_settings_uav_terminal_user_visible_in_spectrum">
+            <English>UAV terminal user visible in spectrum</English>
+        </Key>
+        <Key ID="STR_CROWSEW_Spectrum_settings_uav_terminal_user_visible_in_spectrum_tooltip">
+            <English>Shall UAV terminal users be visible in the spectrum (given they are connected to a UAV)? This makes them susceptible to being jammed by players with a jamming antenna on their Spectrum Device.</English>
+        </Key>
         <Key ID="STR_CROWSEW_Spectrum_sounds_drone_heli_motor">
             <English>Helicopter drone motor</English>
             <Chinesesimp>直升机无人机马达声</Chinesesimp>


### PR DESCRIPTION
resolves #114


Tested using
```sqf
Type: Public
Build: Stable
Version: 2.18.152405

hemtt 1.14.2
```

Unlike what I stated in https://github.com/Crowdedlight/Crows-Electronic-Warfare/issues/114#issuecomment-2657770972 I used a **fixed signal range**, rather than dynamically adjusting it to `player distance uav`.

Note that this requires `GVAR(selfTracking)` to be turned on to actually see yourself in the spectrum.

- [x] CBA setting that turns feature on and off
- [x] disconnect player from UAV when player is being jammed

