### PR TITLE
fix spectrumAutoline above water

### DIFF
--- a/addons/spectrum/functions/fnc_drawSpectrumLine.sqf
+++ b/addons/spectrum/functions/fnc_drawSpectrumLine.sqf
@@ -25,7 +25,7 @@ _colour = GVAR(spectrumAutolineColours) # _colour;
 private _freq = ((missionNamespace getVariable ["#EM_SelMin", 141.6]) + (missionNamespace getVariable ["#EM_SelMax", 141.9]))/2;
 _freq = _freq toFixed 1;
 
-private _startPos = [[[position player, GVAR(spectrumAutolineNoise)]]] call BIS_fnc_randomPos;
+private _startPos = [[[position player, GVAR(spectrumAutolineNoise)]], []] call BIS_fnc_randomPos;
 private _endPos = _startPos getPos [GVAR(spectrumAutolineLength), getDir player];
 
 private _marker_prefix = "_USER_DEFINED"+(getPlayerUID player)+str(getPos player)+str(getDir player)+_freq;


### PR DESCRIPTION
fixes #134

Tested using:

```sqf

Type: Public
Build: Stable
Version: 2.18.152405

hemtt 1.14.5
```

Screenshot of test shows the SD operator on board a [USS Liberty destroyer](https://armedassault.fandom.com/wiki/USS_Liberty). GPS panel on the left shows the `spectrumAutoline`.
![image](https://github.com/user-attachments/assets/f9148d07-47da-4c1b-ba1b-d0fb3028d2e3)
