### PR TITLE
"JAMMED!" label for remote controlling Zeus

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -39,7 +39,7 @@ workshop = [
     "450814997",  # CBA_A3's Workshop ID
     "894678801",  # TFAR Beta
     "1779063631", # Zeus Enhanced 
-    "2369477168", # Advanced Developer Tools
+    "3499977893", # Advanced Developer Tools
     "463939057",  # ACE
     "1645973522", # Intercept Minimal Dev
     "1585582292", # Arma Debug Engine
@@ -53,7 +53,7 @@ workshop = [
     "450814997",  # CBA_A3's Workshop ID
     "894678801",  # TFAR Beta
     "1779063631", # Zeus Enhanced 
-    "2369477168", # Advanced Developer Tools
+    "3499977893", # Advanced Developer Tools
     "463939057",  # ACE
     #"1645973522", # Intercept Minimal Dev
     #"1585582292", # Arma Debug Engine
@@ -67,7 +67,7 @@ workshop = [
     "450814997",  # CBA_A3's Workshop ID
     "751965892",  # ACRE2
     "1779063631", # Zeus Enhanced 
-    "2369477168", # Advanced Developer Tools
+    "3499977893", # Advanced Developer Tools
     "463939057",  # ACE
     #"1645973522", # Intercept Minimal Dev
     #"1585582292", # Arma Debug Engine

--- a/addons/spectrum/XEH_PREP.hpp
+++ b/addons/spectrum/XEH_PREP.hpp
@@ -6,6 +6,7 @@ PREP(updateBeacons);
 PREP(beaconLoopServer);
 PREP(spectrumAttachmentLocal);
 PREP(getAntennaFromFrequency);
+PREP(disconnectPlayerUAV);
 PREP(toggleRadioTracking);
 PREP(radioTrackingBroadcastLocal);
 PREP(addRandomRadioTrackingChatterServer);

--- a/addons/spectrum/XEH_postInit.sqf
+++ b/addons/spectrum/XEH_postInit.sqf
@@ -32,7 +32,7 @@ if (!hasInterface) exitWith {};
 GVAR(trackerUnit) = player; // what unit is used as tracker. Nessecary for zeus RC support
 
 // EH for jamming disconnects
-[QGVAR(disconnectPlayerUAV), {_this#0 connectTerminalToUAV objNull;}] call CBA_fnc_addEventHandler;
+[QGVAR(disconnectPlayerUAV), FUNC(disconnectPlayerUAV) ] call CBA_fnc_addEventHandler;
 
 // event listener to enable/disable TFAR signal sourcing
 private _tfarTrackingId = [QGVAR(toggleRadioTracking), FUNC(toggleRadioTracking)] call CBA_fnc_addEventHandler;

--- a/addons/spectrum/functions/fnc_disconnectPlayerUAV.sqf
+++ b/addons/spectrum/functions/fnc_disconnectPlayerUAV.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*/////////////////////////////////////////////////
+Author: b-mayr-1984 - Bernhard Mayr
+			   
+File: fnc_disconnectPlayerUAV.sqf
+Parameters: _player 	player that shall be disconnected from drone
+			_drone		the drone from which to disconnect
+
+Return: n.a.
+
+Script is used to disconnect players, that are currently remote controlling a drone, 
+from said drone.
+
+Includes special case handling for Zeuses that are remote controlling via Zeus.
+
+*///////////////////////////////////////////////
+
+params [["_player", objNull 	/* player that shall be disconnected from drone */],
+		["_drone",  objNull 	/* the drone from which to disconnect */]];
+
+if (isNull _player || isNull _drone) exitWith {};	// sanity check
+
+_player connectTerminalToUAV objNull;	// disconnect player from any drone
+
+//detect a remote controlling Zeus
+if (isNull (getConnectedUAV _player)  &&  _player in (UAVControl _drone) ) then {
+    // systemChat "This player is remote controlling a unit as Zeus";
+
+	// display red JAMMED message sligthly above center of screen
+	[parseText "<t color='#ff0000'>JAMMED!</t>",-1,0.3,0.2,0.1,0,789] spawn BIS_fnc_dynamicText;
+};

--- a/addons/spectrum/functions/fnc_toggleJammingOnUnit.sqf
+++ b/addons/spectrum/functions/fnc_toggleJammingOnUnit.sqf
@@ -97,7 +97,7 @@ if (_enableJam) then {
 				_droneUsers pushBack _unit;
 			};
 			{
-				[QGVAR(disconnectPlayerUAV), [_x], _x] call CBA_fnc_targetEvent;
+				[QGVAR(disconnectPlayerUAV), [_x, _unit], _x] call CBA_fnc_targetEvent;
 				[QEGVAR(zeus,hintPlayer), ["STR_CROWSEW_Spectrum_hints_jammed_drone"], _x] call CBA_fnc_targetEvent; // notify player why this happened 
 				/* NOTE: Don't use Structured Text for the remote executed hint or the server will show "Performance warning" messages in RPT log.
 				         (see https://community.bistudio.com/wiki/Structured_Text for details)  */


### PR DESCRIPTION
As disussed in #140, this will add a **warning label for a remote controlling Zeus**, when the drone that Zeus is controlling is being jammed.

![image](https://github.com/user-attachments/assets/a9be6355-9fed-43d3-8488-61a1375c0228)

The label will blink with an interval determined by this `sleep` command:
https://github.com/Crowdedlight/Crows-Electronic-Warfare/blob/55d10d7571238e77ecbff5c2f3e2cdb1f4333646/addons/spectrum/functions/fnc_toggleJammingOnUnit.sqf#L106

Might feel annoying to some people, but I guess in this use case it's a feature and not a bug.


Tested using
```sqf
Type: Public
Build: Stable
Version: 2.20.152939

hemtt 1.16.1
```

