### PR TITLE
Lambs integration

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -43,7 +43,8 @@ workshop = [
     "463939057",  # ACE
     "1645973522", # Intercept Minimal Dev
     "1585582292", # Arma Debug Engine
-    "1858075458", # LAMBS Danger
+    # "1858075458", # LAMBS Danger
+    "2434257231", # LAMBS Danger (Dev)
 ]
 mission = "dev_mini.Enoch" # Launch into existing Editor Mission
 parameters = [

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -43,6 +43,7 @@ workshop = [
     "463939057",  # ACE
     "1645973522", # Intercept Minimal Dev
     "1585582292", # Arma Debug Engine
+    "1858075458", # LAMBS Danger
 ]
 mission = "dev_mini.Enoch" # Launch into existing Editor Mission
 parameters = [

--- a/addons/spectrum/CfgSettings.hpp
+++ b/addons/spectrum/CfgSettings.hpp
@@ -1,0 +1,14 @@
+
+class CfgSettings {
+    class CBA {
+        class Versioning {
+            class PREFIX {
+                class dependencies {
+                    //Warnings for LAMBS version being too low
+                    LAMBS[] = {"lambs_main", {3,6,1,502}, "isClass (configFile >> 'CfgPatches' >> 'lambs_main')"};
+             // TODO: add proper version here ^^^
+                };
+            };
+        };
+    };
+};

--- a/addons/spectrum/XEH_PREP.hpp
+++ b/addons/spectrum/XEH_PREP.hpp
@@ -38,3 +38,4 @@ PREP(ctrackHandleGetInVehicle);
 PREP(ctrackHandleGetOutVehicle);
 PREP(ctrackHandleKilled);
 PREP(spectrumGUI);
+PREP(lambsShareInformationHandler);

--- a/addons/spectrum/XEH_postInit.sqf
+++ b/addons/spectrum/XEH_postInit.sqf
@@ -1,5 +1,19 @@
 #include "script_component.hpp"
 
+
+// register a custom ShareInformationHandler at LAMBS danger (if available) for both server and clients
+private _lambsConfig = configFile >> "CfgPatches" >> "lambs_main";
+private _hasLAMBS = isClass(_lambsConfig);
+if (_hasLAMBS) then {
+	// check LAMBS for minimum required version
+	private _LAMBSversion = [_lambsConfig,"versionAr"] call BIS_fnc_returnConfigEntry;
+	diag_log format ["CrowsEW-spectrum: LAMBS version %1 detected", _LAMBSversion]; // debug output
+	// TODO: exitWith in case version is to low
+
+	[FUNC(lambsShareInformationHandler)] call lambs_main_fnc_addShareInformationHandler;
+};
+
+
 // if server, set eventhandlers for server 
 if (isServer) then {
 	// event listener for adding trackable random radio chatter on units - server only
@@ -65,3 +79,4 @@ if (!EGVAR(zeus,hasAce)) then {
 
 // request current state of beacons - for JIP/init
 [QGVAR(requestBeacons), [player]] call CBA_fnc_serverEvent;
+

--- a/addons/spectrum/config.cpp
+++ b/addons/spectrum/config.cpp
@@ -27,3 +27,4 @@ PRELOAD_ADDONS;
 #include "radio_ids.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
+#include "CfgSettings.hpp"

--- a/addons/spectrum/functions/fnc_lambsShareInformationHandler.sqf
+++ b/addons/spectrum/functions/fnc_lambsShareInformationHandler.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+/*/////////////////////////////////////////////////
+Author: b-mayr-1984 - Bernhard Mayr
+			   
+File: fnc_lambsShareInformationHandler.sqf
+Parameters: 
+ * 0: unit sharing information <OBJECT>
+ * 1: enemy target <OBJECT>
+ * 2: range to share information, default 350 <NUMBER>
+ * 3: override radio ranges, default false <BOOLEAN>
+ * 4: group member doing the actual radio call <OBJECT>
+ * 5: sharing range after adjusting for radio ranges <NUMBER> 	
+ * 6: unit has a long range radio <BOOLEAN>
+
+Return: false     in order to not suppress information sharing in LAMBS
+
+Script is primarily used to have an omni-directional C-UAS jammer 
+show up as a destinct shape in the Spectrum Device.
+
+*///////////////////////////////////////////////
+
+params [["_unit",     objNull, [objNull]], 
+		["_target",   objNull, [objNull]], 
+		["_range",    350,     [1337]], 
+		["_override", false,   [true]], 
+		["_newUnit",  objNull, [objNull]], 
+		["_newRange", 350,     [1337]],
+		["_radio",    false,   [true]]];
+
+
+diag_log format format ["%1, %2, %3", _unit, _newRange, _radio]; 	// debug output
+
+// private _inventoryRadio = "ItemRadio" in (assignedItems _unit);		// check if AI has has a SR radio equipped
+// private _hasRadio = _radio || _inventoryRadio;
+
+private _transmitEM = (_newRange > 150);	// radio is assumed if communication range is larger than 150m
+if (_transmitEM) then {
+	private _maxFreq = GVAR(spectrumDeviceFrequencyRange)#0#1;
+	if (_radio) then { _maxFreq = 87; };	// if unit has LR radio, limit max frequency to 87MHz (TFAR LR radio range)
+
+	private _frequency = hashValue (side _unit);	// frequency the information is transmitted on should be unique per side
+	_frequency = (_frequency mod (GVAR(spectrumDeviceFrequencyRange)#0#0 + _maxFreq)) - GVAR(spectrumDeviceFrequencyRange)#0#0 ;	// normalize frequency to TFAR range
+
+	private _transmitTime = 5 + (random 10);	// time it takes to transmit the information
+};
+
+false; // return false to not suppress information sharing in LAMBS

--- a/addons/spectrum/script_component.hpp
+++ b/addons/spectrum/script_component.hpp
@@ -17,6 +17,9 @@
 
 #include "\z\crowsEW\addons\main\script_macros.hpp"
 
-#define PRIVATE 0 //unusable - only for inheritance
-#define HIDDEN 1 //Hidden in Editor/Curator/Arsenal
-#define PUBLIC 2 //usable and visible
+//PRIVATE means unusable - only for inheritance
+//HIDDEN means hidden in Editor/Curator/Arsenal
+//PUBLIC means usable and visible
+#define PRIVATE 0
+#define HIDDEN 1
+#define PUBLIC 2


### PR DESCRIPTION
This aims at implementing #43 (and thus parts of #159).

As of now it can not be considered done. 
But it has progressed far enough so that it can be demonstrated/tested.
- requires https://github.com/nk3nny/LambsDanger/pull/444 be build (e.g. with `hemtt dev`) before game is launched via CrowsEW's own `hemtt launch`

Open topcis:
- [x] wait for https://github.com/nk3nny/LambsDanger/pull/444 be merged and [have it released on the Steam workshop](https://steamcommunity.com/sharedfiles/filedetails/changelog/1858075458) before pushing CrowsEW with this feature into the Steam workshop
  - even though mechanism in [CfgSettings.hpp](https://github.com/b-mayr-1984/Crows-Electronic-Warfare/blob/0f2749153d6a302e202b4fe571b48d0973f121fe/addons/spectrum/CfgSettings.hpp) can help
- [ ] implement plausible audible content (as of now it is just generic British radio `"chatter"`)
- [ ] implement more radio nets (meaning transmit frequencies) than just one per side

@SewerynRoznowski, @OverlordZorn, @Crowdedlight I am happy to take your feedback regarding this feature