### PR TITLE
Add warning message in single player

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -1,7 +1,10 @@
 #include "script_component.hpp"
 
 //Don't do anything in Singleplayer, as TFAR isn't enabled in SP
-if (!isMultiplayer && !is3DENMultiplayer) exitWith {};
+if (!isMultiplayer && !is3DENMultiplayer) exitWith {
+	systemChat "CrowsEW will not work properly in singleplayer mode!!! Please restart in multiplayer mode.";
+	diag_log "CrowsEW started in singleplayer mode. Some features will not work.";
+};
 
 // if not a player we don't do anything
 if (isServer) then {


### PR DESCRIPTION
fix #165


Will add this `systemChat` message for players.
<img width="432" height="45" alt="image" src="https://github.com/user-attachments/assets/30c9437b-13f2-459d-b1f9-4152f8e1755a" />

And puts this into the RPT log:
```sqf
21:42:10 "CrowsEW started in singleplayer mode. Some features will not work."
```
