### PR TITLE
added api to add custom sounds to playSound and addSound modules

### DIFF
--- a/addons/sounds/XEH_PREP.hpp
+++ b/addons/sounds/XEH_PREP.hpp
@@ -6,3 +6,5 @@ PREP(getSoundPath);
 PREP(removeSound);
 PREP(setSoundEnable);
 PREP(playSoundPos);
+PREP(refreshSoundArray);
+PREP(addCustomSounds);

--- a/addons/sounds/XEH_preInit.sqf
+++ b/addons/sounds/XEH_preInit.sqf
@@ -82,22 +82,6 @@ GVAR(soundAttributes) set ["crowsEW_transformer_malfunction", [4.4, "z\crowsEW\a
 // Base game sounds - none yet. Might come if I add dubbing
 
 
-// Create array for zeus view once. Takes minimal more memoary but removes the need to iterate static data multiple times in runtime
-private _sortArr = [];
-{
-	// push back [key, displayname]
-	_sortArr pushBack [_x, (_y select 2)];
-} forEach GVAR(soundAttributes);
-
-// sort array
-// _sortArr sort true;
-_sortArr = [_sortArr, [], {_x select 1}, "ASCEND"] call BIS_fnc_sortBy;
-
-// now we gotta split it into display names and keys, which is annoying, but gotta loop it again...
-GVAR(soundZeusDisplayKeys) = [];
-GVAR(soundZeusDisplay) = [];
-{
-	GVAR(soundZeusDisplayKeys) pushBack (_x select 0);
-	GVAR(soundZeusDisplay) pushBack (_x select 1);
-} forEach _sortArr;
+// refresh the sound array for zeus
+[] call FUNC(refreshSoundArray); 
 

--- a/addons/sounds/functions/fnc_addCustomSounds.sqf
+++ b/addons/sounds/functions/fnc_addCustomSounds.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+/*/////////////////////////////////////////////////
+Author: Crowdedlight
+			   
+File: fnc_addCustomSounds.sqf
+Parameters: _newSounds: Array of type: [key, length, filepath, displayname]
+Return: none
+
+Called upon event, adds the sound to the list of active sounds
+
+*///////////////////////////////////////////////
+
+params [["_newSounds", [], [[]]]];
+
+{
+	// sound configs key: [length, filepath, displayname]
+	_x params [["_key", "", [""]], ["_length", 0, [0]], ["_filepath", "", [""]], ["_displayname", "", [""]]];
+
+	// continue if key, length or filepath is default values/incorrect
+	if (_key == "" || _length == 0 || _filepath == "") then {
+		
+		// We errored, log it 
+		diag_log format ["CrowsEW:fnc_addCustomSounds.sqf: _key, _length or _filepath is empty or 0 for: [%1,%2,%3,%4]", _key, _length, _filepath, _displayname]; 
+		
+		continue;
+		};
+
+	// otherwise we add it to the array
+	GVAR(soundAttributes) set [_key, [_length, _filepath, _displayname]];	
+
+} forEach _newSounds;
+
+// refresh the sound array for zeus
+[] call FUNC(refreshSoundArray); 

--- a/addons/sounds/functions/fnc_refreshSoundArray.sqf
+++ b/addons/sounds/functions/fnc_refreshSoundArray.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*/////////////////////////////////////////////////
+Author: Crowdedlight
+			   
+File: fnc_refreshSoundArray.sqf.sqf
+
+Rebuilds the arrays for zeus for the sounds in our sound-hashmap. Called when loaded or if sounds has been added dynamically
+
+*///////////////////////////////////////////////
+
+// Create array for zeus view once. Takes minimal more memoary but removes the need to iterate static data multiple times in runtime
+private _sortArr = [];
+{
+	// push back [key, displayname]
+	_sortArr pushBack [_x, (_y select 2)];
+} forEach GVAR(soundAttributes);
+
+// sort array
+// _sortArr sort true;
+_sortArr = [_sortArr, [], {_x select 1}, "ASCEND"] call BIS_fnc_sortBy;
+
+// now we gotta split it into display names and keys, which is annoying, but gotta loop it again...
+GVAR(soundZeusDisplayKeys) = [];
+GVAR(soundZeusDisplay) = [];
+{
+	GVAR(soundZeusDisplayKeys) pushBack (_x select 0);
+	GVAR(soundZeusDisplay) pushBack (_x select 1);
+} forEach _sortArr;

--- a/wiki/SUMMARY.md
+++ b/wiki/SUMMARY.md
@@ -23,6 +23,7 @@
 # Sound Modules
 -   [AddSound](sounds/addsound.md)
 -   [PlaySound](sounds/playsound.md)
+-   [Add Custom Sounds](sounds/addCustomSounds.md)
 
 # Other Features
 -   [EMP](emp/emp.md)

--- a/wiki/sounds/addCustomSounds.md
+++ b/wiki/sounds/addCustomSounds.md
@@ -5,7 +5,7 @@ This allow mission makers or other modmakers to add sounds to the "AddSound" and
 API call
 ```sqf
 // input param is array consiting of array elements of format `[key, length, filepath, displayname]`
-// key: lowercase unique id for this sound, avoid spaces. Recommend using a personal prefix like: "myprefix_bell_tower"
+// key: unique id for this sound, avoid spaces. Recommend using a personal prefix like: "myprefix_bell_tower"
 // length: the length of the sound in seconds, provide in decimals format e.g. 0.4s
 // filepath: the filepath to the sound file IMPORTANT, this is the path in arma virtual system, e.g for this mod: "z\crowsEW\addons\sounds\data\soundfile.ogg"
 // displayname: the "pretty" name of the sound. So what the zeus will see when selecting it. can contains spaces. 

--- a/wiki/sounds/addCustomSounds.md
+++ b/wiki/sounds/addCustomSounds.md
@@ -1,0 +1,31 @@
+# Add Costum Sound API
+
+This allow mission makers or other modmakers to add sounds to the "AddSound" and "PlaySound" module. 
+
+API call
+```sqf
+// input param is array consiting of array elements of format `[key, length, filepath, displayname]`
+// key: lowercase unique id for this sound, avoid spaces. Recommend using a personal prefix like: "myprefix_bell_tower"
+// length: the length of the sound in seconds, provide in decimals format e.g. 0.4s
+// filepath: the filepath to the sound file IMPORTANT, this is the path in arma virtual system, e.g for this mod: "z\crowsEW\addons\sounds\data\soundfile.ogg"
+// displayname: the "pretty" name of the sound. So what the zeus will see when selecting it. can contains spaces. 
+
+[["key", 0.4, "filepath", "displayname"], ... ] call crowsew_sounds_fnc_addCustomSounds;
+```
+
+```admonish info
+If a sound fails to be added it will write it to the RPT log file. e.g.: "CrowsEW:fnc_addCustomSounds.sqf: _key, _length or _filepath is empty or 0 for: ["",0.0,"",""]"
+```
+
+
+Example:
+```sqf
+
+private _newSounds = [
+	["crowsEW_tiger_roar", 1.8, "z\crowsEW\addons\sounds\data\tiger_roar.ogg", "Tiger Roar (1.8s)"],
+	["crowsEW_tiger_growl", 1.3, "z\crowsEW\addons\sounds\data\tiger_growl.ogg", "Tiger Growl (1.3s)"],
+	["crowsEW_tiger_stamp", 1.1, "z\crowsEW\addons\sounds\data\tiger_stamp.ogg", localize "STR_CROWSEW_Sounds_tiger_stamp"] // if doing localization
+];
+
+[_newSounds] call crowsew_sounds_fnc_addCustomSounds;
+```


### PR DESCRIPTION
Adds api for mission-makers or others to add custom sounds to the addSound and playSound modules. Makes it a bit easier to handle with built-in functions and streamlining it. 

Should deal with #173 

Example: 
```sqf
private _newSounds = [
	["crowsEW_tiger_roar", 1.8, "z\crowsEW\addons\sounds\data\tiger_roar.ogg", "Tiger Roar (1.8s)"],
	["crowsEW_tiger_growl", 1.3, "z\crowsEW\addons\sounds\data\tiger_growl.ogg", "Tiger Growl (1.3s)"],
	["crowsEW_tiger_stamp", 1.1, "z\crowsEW\addons\sounds\data\tiger_stamp.ogg", localize "STR_CROWSEW_Sounds_tiger_stamp"] // if doing localization
];

[_newSounds] call crowsew_sounds_fnc_addCustomSounds;
```